### PR TITLE
Update METER_TO_GRID

### DIFF
--- a/custom_components/sunpower/const.py
+++ b/custom_components/sunpower/const.py
@@ -78,7 +78,7 @@ METER_SENSORS = {
     "METER_L12_V": ["v12_v", "Supply Volts", ELECTRIC_POTENTIAL_VOLT, "mdi:flash",
                     DEVICE_CLASS_VOLTAGE, STATE_CLASS_MEASUREMENT],
     "METER_TO_GRID": ["neg_ltea_3phsum_kwh", "KWH To Grid", ENERGY_KILO_WATT_HOUR, "mdi:flash",
-                      DEVICE_CLASS_ENERGY, STATE_CLASS_TOTAL_INCREASING],
+                      DEVICE_CLASS_ENERGY, STATE_CLASS_TOTAL],
     "METER_TO_HOME": ["pos_ltea_3phsum_kwh", "KWH To Home", ENERGY_KILO_WATT_HOUR, "mdi:flash",
                       DEVICE_CLASS_ENERGY, STATE_CLASS_TOTAL_INCREASING]
 }


### PR DESCRIPTION
Changed the class for Meter_to_grid from state_class_total_increasing to state_class_total to allow for negative values for when Net Metering is in use and Energy is being sold back to the grid